### PR TITLE
Created user detail endpoint and change how to retrieve employee role #60

### DIFF
--- a/backend/user/serializers.py
+++ b/backend/user/serializers.py
@@ -1,14 +1,18 @@
 from .models import Employee
-from django.contrib.auth.models import User
 from rest_framework import serializers
 
 class EmployeeSerializer(serializers.ModelSerializer):
     class Meta:
         model = Employee
-        fields = '__all__'
+        fields = ['user', 'department', 'phone']
     
     def to_representation(self, instance):
         representation = super().to_representation(instance)
+        if instance.role == 'CO':
+            role = 'courier'
+        elif instance.role == 'SA':
+            role = 'admin'
+        representation['role'] = role
         representation['username'] = instance.user.username
         representation['first_name'] = instance.user.first_name
         representation['last_name'] = instance.user.last_name

--- a/backend/user/urls.py
+++ b/backend/user/urls.py
@@ -9,5 +9,6 @@ urlpatterns = [
     path('logout/', views.user_logout, name='logout'),
     path('register/', views.user_registration, name='register'),
     path('list/', views.EmployeeListView.as_view(), name='list'),
-    path('update/<int:pk>/', views.EmployeeUpdateView.as_view(), name='update')
+    path('update/<int:pk>/', views.EmployeeUpdateView.as_view(), name='update'),
+    path('detail/<int:pk>/', views.EmployeeDetailView.as_view(), name='detail')
 ]

--- a/backend/user/views.py
+++ b/backend/user/views.py
@@ -8,7 +8,7 @@ from django.views.decorators.http import require_POST
 from rest_framework.authentication import TokenAuthentication
 from rest_framework.authtoken.models import Token
 from rest_framework.views import APIView
-from rest_framework.generics import ListAPIView, UpdateAPIView
+from rest_framework.generics import ListAPIView, UpdateAPIView, RetrieveAPIView
 from .serializers import EmployeeSerializer
 from rest_framework.permissions import IsAuthenticated
 
@@ -36,7 +36,7 @@ class LoginView(APIView):
             return JsonResponse(
                 dict(
                     id=user.id,
-                    group=group,
+                    group=group,    
                     status=200,
                     message='Admin successfully logged in',
                     token=token.key,
@@ -100,6 +100,11 @@ class EmployeeListView(ListAPIView):
     serializer_class = EmployeeSerializer
 
 class EmployeeUpdateView(UpdateAPIView):
+    permission_classes = [IsAuthenticated]
+    queryset = Employee.objects.all()
+    serializer_class = EmployeeSerializer
+
+class EmployeeDetailView(RetrieveAPIView):
     permission_classes = [IsAuthenticated]
     queryset = Employee.objects.all()
     serializer_class = EmployeeSerializer


### PR DESCRIPTION
- Changed how to representate the employee role ( here we use the `to_representate` function of the serializers model ):

![image](https://github.com/alherdom/Adalogix/assets/90780043/ea4a5d73-ebb3-4d36-b6db-6de77c002c8f)

- Created the employee detail view inheriting from `RetrieveApiView` of Django Rest Framework:

![image](https://github.com/alherdom/Adalogix/assets/90780043/97dc4a5a-bb5d-4d5d-a71a-610ecea66ae5)

- Created the endpoint url:

![image](https://github.com/alherdom/Adalogix/assets/90780043/f50c534a-d89d-4a76-8da6-4da8d49b42f2)

